### PR TITLE
[45기 문유현] feature/main-layout 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.8.0",
         "react-router-dom": "^6.11.2",
         "react-scripts": "5.0.1",
         "react-slick": "^0.29.0",
@@ -14993,6 +14994,14 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-icons": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.8.0",
     "react-router-dom": "^6.11.2",
     "react-scripts": "5.0.1",
     "react-slick": "^0.29.0",

--- a/src/pages/Main/Main.jsx
+++ b/src/pages/Main/Main.jsx
@@ -1,12 +1,43 @@
 import React from 'react';
+import styled from 'styled-components';
 import Dashboard from '../../components/Dashboard/Dashboard';
+import MainFooter from './components/MainFooter';
+import FilterCategory from './components/FilterCategory';
 
 const Main = () => {
   return (
-    <div>
-      <Dashboard />
-    </div>
+    <Container>
+      <FilterCategory />
+      <MainSection>
+        <DashboardWrapper>
+          <Dashboard />
+          <Dashboard />
+          <Dashboard />
+        </DashboardWrapper>
+        <MainFooter />
+      </MainSection>
+    </Container>
   );
 };
 
+const Container = styled.div`
+  display: flex;
+`;
+
+const MainSection = styled.section`
+  width: 85%;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 120px;
+`;
+
+const DashboardWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 30px;
+
+  width: 90%;
+`;
 export default Main;

--- a/src/pages/Main/components/FilterCategory.jsx
+++ b/src/pages/Main/components/FilterCategory.jsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import FilterDetail from './FilterDetail';
+import variables from '../../../styles/variables';
+import { useParams, useSearchParams } from 'react-router-dom';
+
+const FilterCategory = () => {
+  const [feeds, setFeeds] = useState([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { id } = useParams();
+  const [isSorted, setIsSorted] = useState(false);
+
+  const handleSort = sort => {
+    searchParams.set('orderBy', sort);
+    setSearchParams(searchParams);
+  };
+
+  /*   
+// 서버 통신용 코드
+  const FEED_API = `https://localhost:3000`;
+
+  useEffect(() => {
+    fetch(`${FEED_API}/${id}&${searchParams.toString()}`)
+      .then(response => response.json())
+      .then(response => {
+        setFeeds(response);
+      });
+  }, [id, searchParams]); 
+  */
+
+  return (
+    <Container>
+      <button
+        className="sort-button"
+        onClick={() => setIsSorted(prev => !prev)}
+      >
+        <span className="sort-by">정렬 기준</span>
+        <img
+          className="sort-img"
+          alt="더보기"
+          src={`/images/icon/${
+            isSorted ? 'angle-up-solid' : 'angle-down-solid'
+          }.svg`}
+        />
+      </button>
+      {isSorted && (
+        <ul className="sort-list">
+          {SORT_MENU.map(({ id, content, sort }) => (
+            <li key={id} onClick={() => handleSort(sort)}>
+              {content}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {FILTER_TITLE.map(title => {
+        return (
+          <FilterDetail
+            key={title.id}
+            name={title.name}
+            option={title.option}
+          />
+        );
+      })}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  ${variables.flex('column', 'none', 'none')};
+  gap: 20px;
+  width: 15%;
+  padding: 8px 12px;
+`;
+
+export default FilterCategory;
+
+const GENDER_OPTION = [
+  { id: 1, category: 'genderId', content: '남' },
+  { id: 2, category: 'genderId', content: '여' },
+];
+
+const SEASON_OPTION = [
+  { id: 1, category: 'seasonId', content: 'S/S' },
+  { id: 2, category: 'seasonId', content: 'F/W' },
+];
+
+const STYLE_OPTION = [
+  { id: 1, category: 'styleId', content: '캐주얼' },
+  { id: 2, category: 'styleId', content: '댄디' },
+  { id: 3, category: 'styleId', content: '스트리트' },
+  { id: 4, category: 'styleId', content: '스포츠' },
+];
+
+const FILTER_TITLE = [
+  { id: 0, name: '성별', option: GENDER_OPTION },
+  { id: 1, name: '시즌', option: SEASON_OPTION },
+  { id: 2, name: '스타일', option: STYLE_OPTION },
+];
+
+const SORT_MENU = [
+  { id: 0, content: 'Best', sort: 'best' },
+  { id: 1, content: 'Following', sort: 'following' },
+];

--- a/src/pages/Main/components/FilterDetail.jsx
+++ b/src/pages/Main/components/FilterDetail.jsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import variables from '../../../styles/variables';
+import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io';
+import OptionInput from './OptionInput';
+
+const FilterDetail = ({ name, option }) => {
+  const [toggleMore, setToggleMore] = useState(false);
+  const [checkedElement, setCheckedElement] = useState(-1);
+
+  const handleToggleMore = () => {
+    setToggleMore(prev => !prev);
+  };
+
+  return (
+    <FilterBox>
+      <li>
+        {/* title part */}
+        <FilterTitleWrapper onClick={handleToggleMore}>
+          <FilterTitle>{name}</FilterTitle>
+          {toggleMore ? <IoIosArrowUp /> : <IoIosArrowDown />}
+        </FilterTitleWrapper>
+      </li>
+
+      {/* subcategory part */}
+      <CategoryContentWrapper toggleMore={toggleMore}>
+        {option.map(item => {
+          return (
+            <OptionInput
+              key={item.id}
+              item={item}
+              checkedElement={checkedElement}
+              setCheckedElement={setCheckedElement}
+            />
+          );
+        })}
+      </CategoryContentWrapper>
+    </FilterBox>
+  );
+};
+
+const FilterBox = styled.ul`
+  ${variables.flex('column', 'none', 'none')};
+  gap: 10px;
+`;
+
+const FilterTitleWrapper = styled.div`
+  ${variables.flex('none', 'space-between', 'center')};
+
+  cursor: pointer;
+
+  &:hover {
+    border-radius: 8px;
+    background-color: #eee;
+  }
+`;
+
+const FilterTitle = styled.div`
+  ${variables.flex('none', 'none', 'center')};
+  height: 30px;
+  font-size: 24px;
+  font-weight: 700;
+`;
+
+const CategoryContentWrapper = styled.ul`
+  display: ${props => (props.toggleMore ? 'block' : 'none')};
+  padding-left: 15px;
+`;
+
+export default FilterDetail;

--- a/src/pages/Main/components/MainFooter.jsx
+++ b/src/pages/Main/components/MainFooter.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const MainFooter = () => {
+  return (
+    <Container>
+      {FOOTER_DATA.map(footer => {
+        return <FooterItem key={footer.id}>{footer.title}</FooterItem>;
+      })}
+      <CopyRight>&copy; 2023. oneul, Co., LTD. All rights reserved</CopyRight>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  gap: 15px;
+  width: 30%;
+  font-size: 13px;
+  color: #bbb;
+`;
+
+const FooterItem = styled.div`
+  display: flex;
+  height: 5px;
+`;
+
+const CopyRight = styled.div`
+  margin-top: 10px;
+`;
+
+export default MainFooter;
+
+const FOOTER_DATA = [
+  { id: 1, title: '회사소개' },
+  { id: 2, title: '채용정보' },
+  { id: 3, title: '이용약관' },
+  { id: 4, title: '공지사항' },
+  { id: 5, title: '개인정보 처리방침' },
+  { id: 6, title: '제휴/광고 문의' },
+  { id: 7, title: '상품광고 소개' },
+  { id: 8, title: '고개의 소리' },
+];
+
+/* const BUSINESS_INFO = [
+  { id: 1, title: '(주)오늘뭐입지' },
+  { id: 2, title: '대표이사 박현아' },
+  { id: 3, title: '서울 서초구 선릉로 위워크 10층' },
+  { id: 4, title: 'contact@oneulmoipzi.com' },
+  { id: 5, title: '사업자등록번호 000-11-112345' },
+
+]; */

--- a/src/pages/Main/components/OptionInput.jsx
+++ b/src/pages/Main/components/OptionInput.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import styled from 'styled-components';
+import variables from '../../../styles/variables';
+import { BsCheckCircleFill, BsCheckCircle } from 'react-icons/bs';
+import { useSearchParams } from 'react-router-dom';
+
+const OptionInput = ({
+  item: { id, category, content },
+  setCheckedElement,
+  checkedElement,
+}) => {
+  const handleRadioButton = e => {
+    setCheckedElement(Number(e.target.value));
+    searchParams.set(category, e.target.value);
+    setSearchParams(searchParams);
+  };
+
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  return (
+    <OptionWrapper>
+      <input
+        type="radio"
+        value={id}
+        checked={checkedElement === id}
+        onChange={handleRadioButton}
+      />
+      {checkedElement === id ? (
+        <BsCheckCircleFill className="radioIcon" />
+      ) : (
+        <BsCheckCircle />
+      )}
+      <OptionText>{content}</OptionText>
+    </OptionWrapper>
+  );
+};
+
+const OptionWrapper = styled.label`
+  ${variables.flex('none', 'none', 'center')};
+  gap: 8px;
+  margin-bottom: 8px;
+
+  input {
+    display: none;
+  }
+
+  .radioIcon {
+    color: ${props => props.theme.style.orange};
+  }
+`;
+
+const OptionText = styled.div``;
+
+export default OptionInput;


### PR DESCRIPTION
"기존의  feature/main-layout 브랜치 내 오류로 인해 feature/main-layout 2 신규 브랜치를 생성하여 pr 올립니다. "
Add : Main layout, Main filtering querystring function - sorting 전

## 1. 본 PR이 우리 팀의 웹 서비스 제품성에 어떠한 기여를 하였고, 사용자에게 어떠한 기대효과를 전달하는지 작성해주세요.
- 내 PR이 제품 내 어떠한 기능적인 배경/전후맥락 가운데 개발되었나요?

리스트 페이지를 따로 두지 않고, 메인 페이지에서 원하는 피드(패션 카테고리)별로 볼 수 있게 레이아웃을 구성했기 때문에 고객이 리스트 페이지라는 한 단계를 더 거치지 않고서도 편하게 커뮤니티를 브라우징할 수 있습니다.
화면이 reload/refresh되더라도 선택한 카테고리를 필터링한 쿼리스트링은 url에 남아있게 하여, 기존에 선택한 카테고리를 다시 선택하지 않더라도 편하게 필터링된 피드를 볼 수 있도록 구현했습니다.

- 내 PR이 Merge 됨으로써 유저에게 전달되는 편익/기대효과는 무엇일까요?

고객이 궁금한 패션 카테고리에 맞게 피드를 볼 수 있도록 레이아웃을 구성했습니다.





<br />

## 2. 이 브랜치에서 어떤 내용을 개발했는지 큰 제목과 그리고 상세 내역을 적어주세요.

메인 레이아웃

카테고리 필터에 호버 시, 백그라운드 컬러를 변경하여 클릭이 가능함을 보여줍니다.
input radio를 상수데이터와 map을 통해 구현했습니다.
사용자가 선택한 카테고리가 쿼리스트링으로 반영되도록 구현했습니다.


<br />

## 3. 개발한 화면을 캡쳐해서 첨부 해 주세요. (drag & drop 또는 첨부파일 추가)
<br />

![image](https://github.com/wecode-bootcamp-korea/45-2nd-BESTful-frontend/assets/121086010/6691aa23-aa15-40da-ab5f-683054e6fe3b)

<br />

## 4. 이 브랜치에서 개발하면서 느꼇던 개발 성장포인트를 적어주세요.

상수데이터와 map 메서드로 반복되는 UI를 그릴 수 있게 됐습니다.

map 메서드를 사용할 때, 부모에서 state를 관리하는 것이 아닌, 자식 컴포넌트에서 state를 관리해야 개별적으로 기능이 구현됨을 배웠습니다.

자식에서 state를 관리하는 것이 아닌, 부모에서 자식의 id를 인자로 넘겨주는 콜백함수를 통해서 자식 컴포넌트와 부모 컴포넌트의 id가 일치하는 경우 아코디언 효과가 나타나도록 구현하는 방법에 대해 추가적으로 공부해야겠습니다.

리액트 아이콘 라이브러리 사용 방법을 익힐 수 있었습니다.

useEffect 내의 의존성 배열에 의해 리렌더링되며 쿼리스트링에 적었던 로직이 제대로 구현되지 않는 에러를 해결하며, useEffect 개념에 대해 다시 공부할 수 있었습니다. 

  <br />
